### PR TITLE
Fix astoid version

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2,3 +2,4 @@ diff-cover
 
 Copyright 2013-2014, edX
 
+Copyright 2015, Matt Bachmann

--- a/README.rst
+++ b/README.rst
@@ -266,26 +266,23 @@ For example, setting up python 3:
     pip install -r test-requirements-py27-py3.txt
 
 
-Reporting Security Issues
+Special Thanks
 -------------------------
 
-Please do not report security issues in public. Please email security@edx.org
+Shout out to the original author of diff-cover `Will Daly 
+<https://github.com/wedaly>`_ and the original author of diff-quality `Sarina Canelake 
+<https://github.com/sarina>`_. 
+
+Originally created with the support of `edX 
+<https://github.com/edx>`_.
 
 
-Mailing List and IRC Channel
-----------------------------
-
-You can discuss this code on the `edx-code Google Group`__ or in the
-``edx-code`` IRC channel on Freenode.
-
-__ https://groups.google.com/forum/#!forum/edx-code
-
-.. |build-status| image:: https://travis-ci.org/edx/diff-cover.png
-    :target: https://travis-ci.org/edx/diff-cover
+.. |build-status| image:: https://travis-ci.org/Bachmann1234/diff-cover.png
+    :target: https://travis-ci.org/Bachmann1234/diff-cover
     :alt: Build Status
-.. |coverage-status| image:: https://coveralls.io/repos/edx/diff-cover/badge.png
-    :target: https://coveralls.io/r/edx/diff-cover
+.. |coverage-status| image:: https://coveralls.io/repos/Bachmann1234/diff-cover/badge.png
+    :target: https://coveralls.io/r/Bachmann1234/diff-cover
     :alt: Coverage Status
-.. |requirements-status| image:: https://requires.io/github/edx/diff-cover/requirements.png?branch=master
-    :target: https://requires.io/github/edx/diff-cover/requirements/?branch=master
+.. |requirements-status| image:: https://requires.io/github/Bachmann1234/diff-cover/requirements.png?branch=master
+    :target: https://requires.io/github/Bachmann1234/diff-cover/requirements/?branch=master
     :alt: Requirements Status

--- a/requirements/test-requirements-py26.txt
+++ b/requirements/test-requirements-py26.txt
@@ -1,3 +1,4 @@
 # Requirements for developing on python 2.6
+astroid<=1.3.2
 pylint<=1.3.0 # rq.filter: >=1.3,<1.3.1
 -r test-requirements.txt


### PR DESCRIPTION
I submitted a PR to the pylint project to fix this issue on their side

But this PR fixes it on our side

https://bitbucket.org/logilab/pylint/pull-request/215/astroid-broke-python-26-support-by-using/diff